### PR TITLE
Adds a little more  documentation and structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,9 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# project-specific
 secrets.py
+*.pyc
+data/*
+!data/.keep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # dspace-data-collection
+
+expects a secrets.py file something like the following:
+```
+baseURL='https://dspace.myuni.edu'
+# credentials for an authorized dspace user
+email='dspace_user@.myuni.edu'
+password='my_dspace_password'
+# full path to a directory into which to store output
+filePath = '/Users/dspace_user/dspace-data-collection/data/'
+# handlePrefix may vary from your dspace url (or may not)
+handlePrefix = 'http://dspace.myuni.edu/handle/'
+```
+this file will be gitignored.


### PR DESCRIPTION
Documents the secrets.py file expected by the project.
Gitignores any .pyc files python creates while running scripts.
Adds a local data directory and gitignores its contents.